### PR TITLE
日本酒一覧で検索した際に2ページ目意向が見れなくなっていたバグを直す

### DIFF
--- a/pages/sakes/index.vue
+++ b/pages/sakes/index.vue
@@ -7,20 +7,20 @@
     <hr>
     <div class="col-md-8">
       <div class="input-group mb-3">
-        <input type="text" class="form-control" v-model="searchText" />
+        <input type="text" class="form-control" v-model="searchName" />
         <div class="input-group-append">
           <b-button
             variant="secondary"
             type="button"
-            @click="page = 1; searchByName();"
+            @click="page = 1; search();"
           >検索</b-button>
         </div>
-        <input type="text" class="form-controll" v-model="types" />
+        <input type="text" class="form-controll" v-model="searchTypes" />
         <div class="input-group-append">
           <b-button
             variant="secondary"
             type="button"
-            @click="page = 1; searchByTypes();"
+            @click="page = 1; search();"
           >タグで検索</b-button>
         </div>
       </div>
@@ -63,13 +63,12 @@ export default {
 
       sakes: [],
       searchValue: null,
-      searchText: "",
+      searchName: "",
       types: '',
-      typeQuery: [],
       page: 1,
       count: 0,
       limit: 10,
-
+      searchTypesQuery: []
     };
   },
   async asyncData(context){
@@ -98,14 +97,12 @@ export default {
       return {params: params};
     },
 
-    retrieves(name='', types=[]) {
-      let search = name
-      const typeQuery = types
+    retrieves () {
       const params = this.getRequestParams(
-        search,
+        this.searchName,
         this.page,
         this.limit,
-        typeQuery
+        this.searchTypesQuery
       );
 
       this.$axios.get('/api/sakes', params)
@@ -122,14 +119,10 @@ export default {
       this.page = value;
       this.retrieves();
     },
-    searchByName () {
-      const name = this.searchText;
-      this.retrieves(name,[])
+    search () {
+      this.searchTypesQuery = this.searchTypes.split(/[\s|　]+/);
+      this.retrieves()
     },
-    searchByTypes () {
-      const typeQuery = this.types.split(/[\s|　]+/);
-      this.retrieves('',typeQuery);
-    }
   }
 }
 </script>

--- a/pages/sakes/index.vue
+++ b/pages/sakes/index.vue
@@ -68,6 +68,7 @@ export default {
       page: 1,
       count: 0,
       limit: 10,
+      searchTypes: '',
       searchTypesQuery: []
     };
   },
@@ -80,10 +81,10 @@ export default {
     }
   },
   methods: {
-    getRequestParams(searchText, page, limit, typeQuery) {
+    getRequestParams(searchName, page, limit, searchTypesQuery) {
       let params = {};
-      if (searchText) {
-        params["keyword"] = searchText;
+      if (searchName) {
+        params["keyword"] = searchName;
       }
       if (page) {
         params["page"] = page;
@@ -91,8 +92,8 @@ export default {
       if (limit) {
         params["limit"] = limit;
       }
-      if (typeQuery) {
-        params["typeQuery"] = typeQuery;
+      if (searchTypesQuery.length > 0) {
+        params["typeQuery"] = searchTypesQuery;
       }
       return {params: params};
     },

--- a/pages/sakes/index.vue
+++ b/pages/sakes/index.vue
@@ -92,7 +92,7 @@ export default {
       if (limit) {
         params["limit"] = limit;
       }
-      if (searchTypesQuery.length > 0) {
+      if (searchTypesQuery[0] !== '') {
         params["typeQuery"] = searchTypesQuery;
       }
       return {params: params};


### PR DESCRIPTION
FIX #30 
## このPRでやっていること

- 日本酒一覧で検索した際に2ページ目意向が見れなくなっていたバグを直す
- 変数名をちょっと整理

## 実装方法
`retrieves()`で常に`this.searchName`と`this.searchTypesQuery`を見ることで、ページが変わった際も検索のinputに入っている文字列を参照するようにする

## 動作確認
- [x] 名前で検索した際に2ページ目以降が見れる
- [x] タグで検索した際に2ページ目以降が見れる