### PR TITLE
日本酒詳細でリンクをクリック時に正しくそのリンクに遷移できるようにする

### DIFF
--- a/pages/sakes/_id/index.vue
+++ b/pages/sakes/_id/index.vue
@@ -33,7 +33,7 @@
       <dt>説明</dt>
       <dd>{{ sake.description }}</dd>
       <dt>URL</dt>
-      <dd><nuxt-link v-if="sake.url" :to="sake.url">{{sake.url}}</nuxt-link></dd>
+      <dd><a v-if="sake.url" :href="sake.url">{{sake.url}}</a></dd>
     </dl>
 
     <hr>


### PR DESCRIPTION
FIX #41 

## 動作確認範囲
- [x] 日本酒詳細のurlをクリックすると記載されているurlがそのまま開かれる