### PR TITLE
日本酒詳細でタグをクリックした際にそのタグで検索が走るようにする

### DIFF
--- a/pages/sakes/_id/index.vue
+++ b/pages/sakes/_id/index.vue
@@ -27,7 +27,7 @@
       <dt>分類</dt>
       <dd>
         <h3>
-          <span v-for="type in sake.type" class="badge badge-pill badge-primary p-2 m-1">{{ type }}</span>
+          <nuxt-link v-for="type in sake.type" :to="'/sakes/?type=' + type" class="badge badge-pill badge-primary p-2 m-1">{{ type }}</nuxt-link>
         </h3>
       </dd>
       <dt>説明</dt>

--- a/pages/sakes/_id/index.vue
+++ b/pages/sakes/_id/index.vue
@@ -27,7 +27,7 @@
       <dt>分類</dt>
       <dd>
         <h3>
-          <nuxt-link v-for="type in sake.type" :to="'/sakes/?type=' + type" class="badge badge-pill badge-primary p-2 m-1" v-bind:key="type">{{ type }}</nuxt-link>
+          <nuxt-link v-for="type in sake.type" :to="'/sakes?type=' + type" class="badge badge-pill badge-primary p-2 m-1" v-bind:key="type">{{ type }}</nuxt-link>
         </h3>
       </dd>
       <dt>説明</dt>

--- a/pages/sakes/_id/index.vue
+++ b/pages/sakes/_id/index.vue
@@ -27,7 +27,7 @@
       <dt>分類</dt>
       <dd>
         <h3>
-          <nuxt-link v-for="type in sake.type" :to="'/sakes/?type=' + type" class="badge badge-pill badge-primary p-2 m-1">{{ type }}</nuxt-link>
+          <nuxt-link v-for="type in sake.type" :to="'/sakes/?type=' + type" class="badge badge-pill badge-primary p-2 m-1" v-bind:key="type">{{ type }}</nuxt-link>
         </h3>
       </dd>
       <dt>説明</dt>

--- a/pages/sakes/index.vue
+++ b/pages/sakes/index.vue
@@ -81,7 +81,7 @@ export default {
     }
   },
   mounted() {
-    this.searchTypes = this.$route.query.type;
+    this.searchTypes = this.$route.query.type ?? '';
     this.search()
   },
   methods: {

--- a/pages/sakes/index.vue
+++ b/pages/sakes/index.vue
@@ -80,6 +80,10 @@ export default {
       count : data.pageCount
     }
   },
+  mounted() {
+    this.searchTypes = this.$route.query.type;
+    this.search()
+  },
   methods: {
     getRequestParams(searchName, page, limit, searchTypesQuery) {
       let params = {};


### PR DESCRIPTION
## このPRでやっていること
表題通りです
FIX #43 
## 実装方法
タグをクリックした場合は`/sakes?type=純米`といったクエリパラメータがついた/sakes‘を開いて、クエリパラメータつきで`/sake`が開かれた際にはmount時に検索する。といったやり方で実装しました。

## 動作確認範囲
- [x] タグをクリックすると検索画面に戻る
- [x] 上記画面で自動で検索が行われる
- [x] 2ページ目以降に遷移することができる
- [x] 検索欄にデフォルトで入力された値を消して別の値を入力して検索することができる
- [x] クエリパラメータなしでも日本酒一覧を開ける