### PR TITLE
enterで検索した際も1ページ目から開始できるようにする

### DIFF
--- a/pages/brands/index.vue
+++ b/pages/brands/index.vue
@@ -7,7 +7,7 @@
     <hr>
     <div class="col-md-8">
       <div class="input-group mb-3">
-        <input type="text" class="form-control" v-model="searchText" @keypress.enter='retrieves'/>
+        <input type="text" class="form-control" v-model="searchText" @keypress.enter='page=1; retrieves();'/>
         <div class="input-group-append">
           <b-button
             variant="secondary"

--- a/pages/breweries/index.vue
+++ b/pages/breweries/index.vue
@@ -7,7 +7,7 @@
     <hr>
     <div class="col-md-8">
       <div class="input-group mb-3">
-        <input type="text" class="form-control" v-model="searchText" @keypress.enter='retrieves'/>
+        <input type="text" class="form-control" v-model="searchText" @keypress.enter='page=1; retrieves();'/>
         <div class="input-group-append">
           <b-button
             variant="secondary"

--- a/pages/bydatas/index.vue
+++ b/pages/bydatas/index.vue
@@ -7,7 +7,7 @@
     <hr>
     <div class="col-md-8">
       <div class="input-group mb-3">
-        <input type="text" class="form-control" v-model="searchText" @keypress.enter='retrieves'/>
+        <input type="text" class="form-control" v-model="searchText" @keypress.enter='page=1; retrieves();'/>
         <div class="input-group-append">
           <b-button
             variant="secondary"

--- a/pages/sakes/index.vue
+++ b/pages/sakes/index.vue
@@ -7,7 +7,7 @@
     <hr>
     <div class="col-md-8">
       <div class="input-group mb-3">
-        <input type="text" class="form-control" v-model="searchName" @keypress.enter='retrieves'/>
+        <input type="text" class="form-control" v-model="searchName" @keypress.enter='page=1; retrieves();'/>
         <div class="input-group-append">
           <b-button
             variant="secondary"
@@ -15,7 +15,7 @@
             @click="page = 1; retrieves();"
           >検索</b-button>
         </div>
-        <input type="text" class="form-control" v-model="searchTypes" @keypress.enter='retrieves'/>
+        <input type="text" class="form-control" v-model="searchTypes" @keypress.enter='page=1; retrieves();'/>
         <div class="input-group-append">
           <b-button
             variant="secondary"


### PR DESCRIPTION
FIX #51 

動作確認
- [x] 日本酒一覧で2ページ目以降にいるときにenterキーで検索したすると1ページ目から始まる
- [x] 上記が銘柄一覧と酒蔵一覧でも再現する