### PR TITLE
ブラウザバックで検索結果に戻れるようにした

### DIFF
--- a/pages/breweries/index.vue
+++ b/pages/breweries/index.vue
@@ -7,12 +7,12 @@
     <hr>
     <div class="col-md-8">
       <div class="input-group mb-3">
-        <input type="text" class="form-control" v-model="searchText" @keypress.enter='page=1; retrieves();'/>
+        <input type="text" class="form-control" v-model="searchText" @keypress.enter='page=1; setHistories(); retrieves();'/>
         <div class="input-group-append">
           <b-button
             variant="secondary"
             type="button"
-            @click="page = 1; retrieves();"
+            @click="page = 1; setHistories(); retrieves();"
           >検索</b-button>
         </div>
       </div>
@@ -68,12 +68,33 @@ export default {
     };
   },
   async asyncData(context){
-    const { list, currentPage, count } = await getList('breweries', {}, context)
+    const searchText = context.query.name ?? ''
+    const limit = context.query.limit ?? 10
+    const page = context.query.page ?? 1
+    const searchTypes = context.query.type ?? ''
+    const typeQuery = searchTypes.split(/[\s|　]+/);
+    const { list, currentPage, count } = await getList('breweries', {
+      searchName: searchText,
+      page: page,
+      limit: limit,
+      ...(typeQuery[0] === '' ? {} : {typeQuery: typeQuery})
+    }, context)
     return {
+      searchText: searchText,
+      searchTypes: searchTypes,
       breweries : list,
       page : currentPage,
       count : count
     }
+  },
+  mounted() {
+    window.addEventListener('popstate', () => {
+      this.searchText = this.$route.query.name ?? ''
+      this.limit = this.$route.query.limit ?? 10
+      this.page = this.$route.query.page ?? 1
+      this.searchTypes = this.$route.query.type ?? ''
+      this.retrieves()
+    });
   },
   methods: {
     async retrieves () {
@@ -88,7 +109,13 @@ export default {
     },
     handlePageChange(value) {
       this.page = value;
+      this.setHistories()
       this.retrieves();
+    },
+    setHistories () {
+      const url = window.location.href.replace(/\?.*$/,"");
+      const queries = `?name=${this.searchText}&type=${this.searchTypes}&page=${this.page}&limit=${this.limit}`;
+      window.history.pushState(null, null, `${url}${queries}`);
     }
   }
 }

--- a/pages/bydatas/index.vue
+++ b/pages/bydatas/index.vue
@@ -7,12 +7,12 @@
     <hr>
     <div class="col-md-8">
       <div class="input-group mb-3">
-        <input type="text" class="form-control" v-model="searchText" @keypress.enter='page=1; retrieves();'/>
+        <input type="text" class="form-control" v-model="searchText" @keypress.enter='page=1; setHistories(); retrieves();'/>
         <div class="input-group-append">
           <b-button
             variant="secondary"
             type="button"
-            @click="page = 1; retrieves();"
+            @click="page = 1; setHistories(); retrieves();"
           >検索</b-button>
         </div>
       </div>
@@ -64,15 +64,35 @@ export default {
     };
   },
   async asyncData(context){
-    const { list, currentPage, count } = await getList('bydatas', {}, context)
+    const searchText = context.query.name ?? ''
+    const limit = context.query.limit ?? 10
+    const page = context.query.page ?? 1
+    const searchTypes = context.query.type ?? ''
+    const typeQuery = searchTypes.split(/[\s|　]+/);
+    const { list, currentPage, count } = await getList('bydatas', {
+      searchName: searchText,
+      page: page,
+      limit: limit,
+      ...(typeQuery[0] === '' ? {} : {typeQuery: typeQuery})
+    }, context)
     return {
+      searchText: searchText,
+      searchTypes: searchTypes,
       bydatas : list,
       page : currentPage,
       count : count
     }
   },
+  mounted() {
+    window.addEventListener('popstate', () => {
+      this.searchText = this.$route.query.name ?? ''
+      this.limit = this.$route.query.limit ?? 10
+      this.page = this.$route.query.page ?? 1
+      this.searchTypes = this.$route.query.type ?? ''
+      this.retrieves()
+    });
+  },
   methods: {
-
     async retrieves () {
       const { list, currentPage, count } = await getList('bydatas', {
         searchName: this.searchText,
@@ -85,7 +105,13 @@ export default {
     },
     handlePageChange(value) {
       this.page = value;
+      this.setHistories();
       this.retrieves();
+    },
+    setHistories () {
+      const url = window.location.href.replace(/\?.*$/,"");
+      const queries = `?name=${this.searchText}&type=${this.searchTypes}&page=${this.page}&limit=${this.limit}`;
+      window.history.pushState(null, null, `${url}${queries}`);
     }
   }
 }

--- a/tests/pages/brands/index.test.js
+++ b/tests/pages/brands/index.test.js
@@ -30,7 +30,8 @@ describe('pages/brands/index.vue', () => {
         'b-button': true
       }
     });
-    const data = await wrapper.vm.$options.asyncData();
+    const context = {query: {name: '', page: '', limit: ''}};
+    const data = await wrapper.vm.$options.asyncData(context);
     wrapper.setData(data);
   });
   it('is a Vue instance', () => {

--- a/tests/pages/breweries/index.test.js
+++ b/tests/pages/breweries/index.test.js
@@ -30,7 +30,8 @@ describe('pages/breweries/index.vue', () => {
         'b-button': true
       }
     });
-    const data = await wrapper.vm.$options.asyncData();
+    const context = {query: {name: '', page: '', limit: ''}};
+    const data = await wrapper.vm.$options.asyncData(context);
     wrapper.setData(data);
   });
   it('is a Vue instance', () => {

--- a/tests/pages/sakes/index.test.js
+++ b/tests/pages/sakes/index.test.js
@@ -38,7 +38,8 @@ describe('pages/sakes/index.vue', () => {
         'b-button': true
       }
     });
-    const data = await wrapper.vm.$options.asyncData();
+    const context = {query: {name: '', page: '', limit: ''}};
+    const data = await wrapper.vm.$options.asyncData(context);
     wrapper.setData(data);
   });
   it('is a Vue instance', () => {


### PR DESCRIPTION
FIX #46 
pushStateで検索条件をクエリパラメータに含ませておいて、他ページに移動して戻ってきた際には`asyncData`でそのクエリパラメータを参照してapiを叩いています
同ページ内でのブラウザバックだと`asyncData`が実行されないようなので`mount`時でpopstate(ブラウザbackとかforwardとか)が発火した際にはasyncdataと似たようなことをするようにしています
動作確認
- [x] 日本酒、銘柄、酒蔵一覧で各ページを開いたあとブラウザバックで検索条件そのままに戻れる
- [x] 検索画面でブラウザバックで前のページに戻れる