### PR TITLE
fromEntriesを使わずに同じことをする

### DIFF
--- a/lib/ApiClient/getList.js
+++ b/lib/ApiClient/getList.js
@@ -8,12 +8,12 @@ export async function getList (type, params, context=undefined) {
 
   // paramsのプロパティのうちundefeindなものを取り除く
   // なくても動く気がする
-  const entries = Object.keys(params).filter((key) => {
+  let queryParam = {}
+  Object.keys(params).filter((key) => {
     return params[key] !== ''
-  }).map((key) => {
-    return [key, params[key]]
+  }).forEach((key) => {
+    queryParam[key] = params[key]
   })
-  const queryParam = Object.fromEntries(entries)
 
   const get = async () => {
     if (context) {


### PR DESCRIPTION
FIX #55 
nodejsのversionが12.0.0未満なことで起きる不具合で、手元のlocalhostでも再現できました
fromEntriesを使わない書き方にすることでエラーが起きないようにしています

動作確認範囲
- [x] nodeのversionを10.0.0にした状態で http://localhost:3030/sakes を開ける
- [x] 検索が使用できる