### PR TITLE
実行後の遷移先調整と投稿更新不具合修正

### DIFF
--- a/api/controllers/commentsController.js
+++ b/api/controllers/commentsController.js
@@ -119,16 +119,14 @@ module.exports.create = [
 module.exports.update = [
   // validations rules
   validator.body('comment').custom((value, { req }) => {
-    console.log('update comments validator');
     return Comment.findOne({ _id: req.params.id }).then((comment) => {
-      if (comment.userId !== req.user._id) {
+      if (comment.userId.toString() != req.user._id.toString()) {
         return Promise.reject('Not your comment');
       }
     });
   }),
 
   function (req, res) {
-    console.log('update comments');
     // throw validation errors
     const errors = validator.validationResult(req);
     if (!errors.isEmpty()) {
@@ -147,7 +145,6 @@ module.exports.update = [
           message: 'No such record',
         });
       }
-      console.log('update comments2');
 
       // initialize record
       data.comment = req.body.comment ? req.body.comment : data.comment;
@@ -155,8 +152,6 @@ module.exports.update = [
       data.brand = req.body.brand ? req.body.brand : data.brand;
       data.brewery = req.body.brewery ? req.body.brewery : data.brewery;
       data.sake = req.body.sake ? req.body.sake : data.sake;
-
-      console.log(req.body);
 
       // save record
       data.save(function (err, data) {

--- a/pages/brands/_id/index.vue
+++ b/pages/brands/_id/index.vue
@@ -108,7 +108,11 @@ export default {
           .delete('/api/brands/' + this.$route.params.id)
           .then((response) => {
             if (response.data._id) {
-              this.$router.push({ name: 'brands', params: { deleted: 'yes' } });
+              this.$store.dispatch('flash/show', {
+                text: '削除しました',
+                mode: 'alert-info',
+              });
+              this.$router.push({ name: 'brands' });
             }
           })
           .catch((error) => {

--- a/pages/brands/_id/update.vue
+++ b/pages/brands/_id/update.vue
@@ -103,7 +103,7 @@ export default {
             });
             this.$router.push({
               name: 'brands-id',
-              params: { updated: 'yes', id: this.$route.params.id },
+              params: { id: this.$route.params.id },
             });
           }
         })

--- a/pages/brands/add.vue
+++ b/pages/brands/add.vue
@@ -102,7 +102,14 @@ export default {
         })
         .then((response) => {
           if (response.data._id) {
-            this.$router.push({ name: 'brands', params: { created: 'yes' } });
+            this.$store.dispatch('flash/show', {
+              text: '追加しました',
+              mode: 'alert-success',
+            });
+            this.$router.push({
+              name: 'brands-id',
+              params: { id: response.data._id },
+            });
           }
         })
         .catch((error) => {

--- a/pages/breweries/_id/index.vue
+++ b/pages/breweries/_id/index.vue
@@ -122,6 +122,10 @@ export default {
           .delete('/api/breweries/' + this.$route.params.id)
           .then((response) => {
             if (response.data._id) {
+              this.$store.dispatch('flash/show', {
+                text: '削除しました',
+                mode: 'alert-info',
+              });
               this.$router.push({ name: 'breweries' });
             }
           })

--- a/pages/breweries/_id/update.vue
+++ b/pages/breweries/_id/update.vue
@@ -524,6 +524,10 @@ export default {
           console.log(response);
 
           if (response.data._id) {
+            this.$store.dispatch('flash/show', {
+              text: '更新しました',
+              mode: 'alert-success',
+            });
             this.$router.push({
               name: 'breweries-id',
               params: { id: this.$route.params.id },

--- a/pages/breweries/add.vue
+++ b/pages/breweries/add.vue
@@ -478,7 +478,14 @@ export default {
         })
         .then((response) => {
           if (response.data._id) {
-            this.$router.push({ name: 'breweries' });
+            this.$store.dispatch('flash/show', {
+              text: '追加しました',
+              mode: 'alert-success',
+            });
+            this.$router.push({
+              name: 'breweries-id',
+              params: { id: response.data._id },
+            });
           }
         })
         .catch((error) => {

--- a/pages/bydatas/_id/index.vue
+++ b/pages/bydatas/_id/index.vue
@@ -87,10 +87,11 @@ export default {
           .delete('/api/bydatas/' + this.$route.params.id)
           .then((response) => {
             if (response.data._id) {
-              this.$router.push({
-                name: 'bydatas',
-                params: { deleted: 'yes' },
+              this.$store.dispatch('flash/show', {
+                text: '削除しました',
+                mode: 'alert-info',
               });
+              this.$router.push({ name: 'bydatas' });
             }
           })
           .catch((error) => {

--- a/pages/bydatas/add.vue
+++ b/pages/bydatas/add.vue
@@ -300,7 +300,14 @@ export default {
         })
         .then((response) => {
           if (response.data._id) {
-            this.$router.push({ name: 'bydatas', params: { created: 'yes' } });
+            this.$store.dispatch('flash/show', {
+              text: '追加しました',
+              mode: 'alert-success',
+            });
+            this.$router.push({
+              name: 'bydatas-id',
+              params: { id: response.data._id },
+            });
           }
         })
         .catch((error) => {

--- a/pages/comments/_id/index.vue
+++ b/pages/comments/_id/index.vue
@@ -98,10 +98,11 @@ export default {
           .delete('/api/comments/' + this.$route.params.id)
           .then((response) => {
             if (response.data._id) {
-              this.$router.push({
-                name: 'comments',
-                params: { deleted: 'yes' },
+              this.$store.dispatch('flash/show', {
+                text: '削除しました',
+                mode: 'alert-info',
               });
+              this.$router.push({ name: 'comments' });
             }
           })
           .catch((error) => {

--- a/pages/comments/_id/update.vue
+++ b/pages/comments/_id/update.vue
@@ -124,7 +124,7 @@ export default {
             });
             this.$router.push({
               name: 'comments-id',
-              params: { updated: 'yes', id: this.$route.params.id },
+              params: { id: this.$route.params.id },
             });
           }
         })

--- a/pages/comments/add.vue
+++ b/pages/comments/add.vue
@@ -141,8 +141,14 @@ export default {
         })
         .then((response) => {
           if (response.data._id) {
-            this.$router.push({ name: 'comments', params: { created: 'yes' } });
-          }
+            this.$store.dispatch('flash/show', {
+              text: '追加しました',
+              mode: 'alert-success',
+            });
+            this.$router.push({
+              name: 'comments-id',
+              params: { id: response.data._id },
+            });          }
         })
         .catch((error) => {
           console.log(error);

--- a/pages/sakes/_id/index.vue
+++ b/pages/sakes/_id/index.vue
@@ -140,7 +140,11 @@ export default {
           .delete('/api/sakes/' + this.$route.params.id)
           .then((response) => {
             if (response.data._id) {
-              this.$router.push({ name: 'sakes', params: { deleted: 'yes' } });
+              this.$store.dispatch('flash/show', {
+                text: '削除しました',
+                mode: 'alert-info',
+              });
+              this.$router.push({ name: 'sakes' });
             }
           })
           .catch((error) => {

--- a/pages/sakes/_id/update.vue
+++ b/pages/sakes/_id/update.vue
@@ -140,7 +140,7 @@ export default {
             });
             this.$router.push({
               name: 'sakes-id',
-              params: { updated: 'yes', id: this.$route.params.id },
+              params: { id: this.$route.params.id },
             });
           }
         })

--- a/pages/sakes/add.vue
+++ b/pages/sakes/add.vue
@@ -155,7 +155,14 @@ export default {
         })
         .then((response) => {
           if (response.data._id) {
-            this.$router.push({ name: 'sakes', params: { created: 'yes' } });
+            this.$store.dispatch('flash/show', {
+              text: '追加しました',
+              mode: 'alert-success',
+            });
+            this.$router.push({
+              name: 'sakes-id',
+              params: { id: response.data._id },
+            });
           }
         })
         .catch((error) => {


### PR DESCRIPTION
追加時の遷移先を詳細ページにする。
実行した内容をフラッシュメッセージで表示。
#132 

自分の投稿の更新ができなかった不具合を合わせて修正
