### PR TITLE
OSMのタイル画像URLをHTTPSにする

### DIFF
--- a/components/BreweriesMap.vue
+++ b/components/BreweriesMap.vue
@@ -39,7 +39,7 @@ export default {
     return {
       center: [35.999887, 138.75],
       zoom: 4,
-      url: 'http://{s}.tile.osm.org/{z}/{x}/{y}.png',
+      url: 'https://{s}.tile.osm.org/{z}/{x}/{y}.png',
       cluster_options: {
         showCoverageOnHover: false,
         maxClusterRadius: 80,


### PR DESCRIPTION
httpsにしないとワーニングが出る。
<img width="562" alt="スクリーンショット 2021-09-28 2 42 54" src="https://user-images.githubusercontent.com/2096703/134958631-ec2b5332-da39-41bd-b57a-6532a07028ad.png">
