### PR TITLE
日本酒更新画面の「説明」が機能していない

### DIFF
--- a/pages/sakes/_id/update.vue
+++ b/pages/sakes/_id/update.vue
@@ -75,7 +75,7 @@
           <div class="form-group">
             <label for="">説明</label>
             <textarea
-              v-model="sake.escription"
+              v-model="sake.description"
               type="text"
               class="form-control"
               :class="{ 'is-invalid': errors && errors.description }"


### PR DESCRIPTION
説明は`description`なのに`escription`になっている。