### PR TITLE
日本酒醸造データから日本酒詳細へ戻れるように、日本酒名をリンクにする。

### DIFF
--- a/pages/bydatas/_id/index.vue
+++ b/pages/bydatas/_id/index.vue
@@ -4,7 +4,11 @@
 
     <hr />
 
-    <h2>{{ bydata.sake ? bydata.sake.name : '' }}</h2>
+    <h2>
+      <nuxt-link v-if="bydata.sake" :to="'/sakes/' + bydata.sake._id">
+        {{ bydata.sake.name }}
+      </nuxt-link>
+    </h2>
     <h4>{{ bydata.makedBY }}年</h4>
     <h6>By {{ author }}</h6>
     <dl>


### PR DESCRIPTION
銘柄、酒蔵の情報は醸造データでは持っていないので、ひとまず日本酒詳細とはリンクできるようにする。