### PR TITLE
issue#97 酒蔵追加画面の必須入力項目を「*必須」で示す

### DIFF
--- a/pages/breweries/add.vue
+++ b/pages/breweries/add.vue
@@ -24,7 +24,7 @@
           </div>
 
           <div class="form-group">
-            <label for="">名前</label>
+            <label for="">名前 <small>*必須</small></label>
             <input
               v-model="name"
               type="text"
@@ -38,7 +38,7 @@
           </div>
 
           <div class="form-group">
-            <label for="">ふりがな</label>
+            <label for="">ふりがな <small>*必須</small></label>
             <input
               v-model="kana"
               type="text"


### PR DESCRIPTION
酒蔵の「名前」と「ふりがな」が必須なので、それぞれ小文字で「＊必須」と付記しました。